### PR TITLE
comment out unused and problematic debug require

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "chroma-js": "0.7.2",
-    "debug": "^2.2.0",
     "is-object": "^1.0.1",
     "object-assign": "^2.0.0"
   },

--- a/src/contrastSearch.coffee
+++ b/src/contrastSearch.coffee
@@ -1,5 +1,5 @@
 chroma = require 'chroma-js'
-debug = require('debug')('color-pairs-picker-binary-search-contrast')
+#debug = require('debug')('color-pairs-picker-binary-search-contrast')
 
 counter = 0
 


### PR DESCRIPTION
I hope this is a valid fix for the issue I am having. The `debug` module isn't being used and it seems to cause issues with webpack, specifically with [gatsby documentation starter](https://github.com/gatsbyjs/gatsby-starter-documentation) when it tries to server render the content.

```
$ gatsby-documentation-site$ gatsby develop

/Users/bojand/dev/js/gatsby-documentation-site/node_modules/debug/src/browser.js:185
if (window) {
^
ReferenceError: window is not defined
    at Object.<anonymous> (/Users/bojand/dev/js/gatsby-documentation-site/node_modules/debug/src/browser.js:185:1)
    at Object.<anonymous> (/bundle.js:7284:31)
    at __webpack_require__ (webpack/bootstrap ae4f019c8ea935b5a246:555:1)
    at fn (webpack/bootstrap ae4f019c8ea935b5a246:86:1)
    at Object.<anonymous> (/Users/bojand/dev/js/gatsby-documentation-site/node_modules/color-pairs-picker/dist/contrastSearch.js:6:1)
    at __webpack_require__ (webpack/bootstrap ae4f019c8ea935b5a246:555:1)
    at fn (webpack/bootstrap ae4f019c8ea935b5a246:86:1)
    at Object.<anonymous> (/Users/bojand/dev/js/gatsby-documentation-site/node_modules/color-pairs-picker/dist/index.js:8:1)
    at __webpack_require__ (webpack/bootstrap ae4f019c8ea935b5a246:555:1)
    at fn (webpack/bootstrap ae4f019c8ea935b5a246:86:1)
```

All tests pass.